### PR TITLE
Add notebook helper to generate text-based task guides

### DIFF
--- a/T1 <Grupo> <10> <DATASET ID>.ipynb
+++ b/T1 <Grupo> <10> <DATASET ID>.ipynb
@@ -1,1 +1,72 @@
-
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuración base para reproducibilidad\n",
+    "GLOBAL_SEED = 42\n",
+    "DATASET_ID = \"<por_definir>\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Guía rápida de la Tarea 1\n",
+    "\n",
+    "Este notebook crea archivos de texto con los puntos clave del enunciado de la tarea, para usarlos como recordatorio durante el desarrollo del proyecto. Ejecuta la celda siguiente para generar la carpeta `guia_tarea/` con un archivo por cada hito requerido.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "pasos = {\n",
+    "    \"01_ETP_y_framing.txt\": \"\"\"1. E–T–P y framing\\n- Describe la Experiencia (E), la Tarea (T) y el Performance/criterio (P).\\n- Define el framing principal como clasificación binaria de `purchase` con salida probabilística.\\n- Justifica si usarás tasas agregadas y la decisión de negocio basada en umbrales.\"\"\",\n",
+    "    \"02_metricas_y_perdida.txt\": \"\"\"2. Métricas y pérdida\\n- Usa log-loss (entropía cruzada) como pérdida principal.\\n- Reporta AUC y Brier score.\\n- Explica por qué MSE no es adecuado como objetivo principal y relaciónalo con máxima verosimilitud.\"\"\",\n",
+    "    \"03_validacion_y_capacidad.txt\": \"\"\"3. Diseño de validación y control de capacidad\\n- Define particiones train/valid/test (70/15/15) o k-fold para escoger hiperparámetros.\\n- Reentrena con los mejores hiperparámetros antes del test.\\n- Controla capacidad con regularización L2 (parámetro C) y grafica curvas train/valid vs complejidad o learning curves.\\n- Explica el trade-off sesgo–varianza.\"\"\",\n",
+    "    \"04_preprocesamiento.txt\": \"\"\"4. Preprocesamiento\\n- Explora el dataset para identificar duplicados, variables irrelevantes o leakage.\\n- Define codificación de variables categóricas, escalamiento y manejo de outliers o nulos según corresponda.\"\"\",\n",
+    "    \"05_modelado_predictivo.txt\": \"\"\"5. Modelado predictivo\\n- Entrena al menos dos modelos de clasificación (ej. regresión logística, árbol, random forest, XGBoost).\\n- Compara su desempeño inicial.\"\"\",\n",
+    "    \"06_evaluacion.txt\": \"\"\"6. Evaluación\\n- Reporta métricas de clasificación: accuracy, precision, recall, F1-score y AUC-ROC.\"\"\",\n",
+    "    \"07_discusion_resultados.txt\": \"\"\"7. Discusión de resultados\\n- Destaca variables relevantes para los modelos.\\n- Justifica columnas excluidas (especialmente leaks).\\n- Propón insights accionables para la empresa.\"\"\",\n",
+    "    \"08_politica_operativa.txt\": \"\"\"8. Política operativa y sensibilidad\\n- Formula una regla clara: contactar/ofrecer si la probabilidad estimada supera el umbral t.\\n- Analiza sensibilidad (ej. utilidad esperada por umbral) y discute implicancias.\"\"\",\n",
+    "    \"09_riesgos_y_mitigacion.txt\": \"\"\"9. Riesgos y mitigación\\n- Identifica al menos tres riesgos: leakage, sesgo de muestreo, shift temporal/segmento.\\n- Propón mitigaciones (auditoría de variables, validación por segmento o fuera de tiempo, calibration, A/B).\"\"\",\n",
+    "    \"10_resultados_y_conclusiones.txt\": \"\"\"10. Resultados y conclusiones\\n- Resume hallazgos clave: saturación, desempeño en test, umbral recomendado.\\n- Indica cómo debe operar la empresa con el modelo final.\"\"\",\n",
+    "    \"extras_opcionales.txt\": \"\"\"Extras opcionales\\n- Mostrar efectos de usar `leak_after_offer` para evidenciar data leakage.\\n- Calcular métricas de negocio (ej. expected profit) usando `unit_margin_if_buy`.\\n- Comparar `discount` numérico vs `discount_bucket`.\"\"\",\n",
+    "    \"requisitos_reproducibilidad.txt\": \"\"\"Formato y reproducibilidad\\n- Declara semilla global y DATASET_ID en la primera celda.\\n- Fija semillas para NumPy/sklearn y repórtalas.\\n- Reporta versiones de librerías y hash SHA-256 del CSV.\\n- Trabaja sólo con el dataset entregado, sin regenerar datos.\\n- Entrega resultados específicos de tu dataset.\"\"\",\n",
+    "}\n",
+    "\n",
+    "destino = Path('guia_tarea')\n",
+    "destino.mkdir(exist_ok=True)\n",
+    "for nombre, contenido in pasos.items():\n",
+    "    ruta = destino / nombre\n",
+    "    ruta.write_text(contenido.strip() + '\n', encoding='utf-8')\n",
+    "\n",
+    "sorted_archivos = sorted(p.name for p in destino.iterdir())\n",
+    "print(f'Se crearon/actualizaron {len(sorted_archivos)} archivos en {destino.resolve()}')\n",
+    "for archivo in sorted_archivos:\n",
+    "    print(f'- {archivo}')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/guia_tarea/01_ETP_y_framing.txt
+++ b/guia_tarea/01_ETP_y_framing.txt
@@ -1,0 +1,4 @@
+1. E–T–P y framing
+- Describe la Experiencia (E), la Tarea (T) y el Performance/criterio (P).
+- Define el framing principal como clasificación binaria de `purchase` con salida probabilística.
+- Justifica si usarás tasas agregadas y la decisión de negocio basada en umbrales.

--- a/guia_tarea/02_metricas_y_perdida.txt
+++ b/guia_tarea/02_metricas_y_perdida.txt
@@ -1,0 +1,4 @@
+2. Métricas y pérdida
+- Usa log-loss (entropía cruzada) como pérdida principal.
+- Reporta AUC y Brier score.
+- Explica por qué MSE no es adecuado como objetivo principal y relaciónalo con máxima verosimilitud.

--- a/guia_tarea/03_validacion_y_capacidad.txt
+++ b/guia_tarea/03_validacion_y_capacidad.txt
@@ -1,0 +1,5 @@
+3. Diseño de validación y control de capacidad
+- Define particiones train/valid/test (70/15/15) o k-fold para escoger hiperparámetros.
+- Reentrena con los mejores hiperparámetros antes del test.
+- Controla capacidad con regularización L2 (parámetro C) y grafica curvas train/valid vs complejidad o learning curves.
+- Explica el trade-off sesgo–varianza.

--- a/guia_tarea/04_preprocesamiento.txt
+++ b/guia_tarea/04_preprocesamiento.txt
@@ -1,0 +1,3 @@
+4. Preprocesamiento
+- Explora el dataset para identificar duplicados, variables irrelevantes o leakage.
+- Define codificación de variables categóricas, escalamiento y manejo de outliers o nulos según corresponda.

--- a/guia_tarea/05_modelado_predictivo.txt
+++ b/guia_tarea/05_modelado_predictivo.txt
@@ -1,0 +1,3 @@
+5. Modelado predictivo
+- Entrena al menos dos modelos de clasificación (ej. regresión logística, árbol, random forest, XGBoost).
+- Compara su desempeño inicial.

--- a/guia_tarea/06_evaluacion.txt
+++ b/guia_tarea/06_evaluacion.txt
@@ -1,0 +1,2 @@
+6. Evaluación
+- Reporta métricas de clasificación: accuracy, precision, recall, F1-score y AUC-ROC.

--- a/guia_tarea/07_discusion_resultados.txt
+++ b/guia_tarea/07_discusion_resultados.txt
@@ -1,0 +1,4 @@
+7. Discusión de resultados
+- Destaca variables relevantes para los modelos.
+- Justifica columnas excluidas (especialmente leaks).
+- Propón insights accionables para la empresa.

--- a/guia_tarea/08_politica_operativa.txt
+++ b/guia_tarea/08_politica_operativa.txt
@@ -1,0 +1,3 @@
+8. Política operativa y sensibilidad
+- Formula una regla clara: contactar/ofrecer si la probabilidad estimada supera el umbral t.
+- Analiza sensibilidad (ej. utilidad esperada por umbral) y discute implicancias.

--- a/guia_tarea/09_riesgos_y_mitigacion.txt
+++ b/guia_tarea/09_riesgos_y_mitigacion.txt
@@ -1,0 +1,3 @@
+9. Riesgos y mitigación
+- Identifica al menos tres riesgos: leakage, sesgo de muestreo, shift temporal/segmento.
+- Propón mitigaciones (auditoría de variables, validación por segmento o fuera de tiempo, calibration, A/B).

--- a/guia_tarea/10_resultados_y_conclusiones.txt
+++ b/guia_tarea/10_resultados_y_conclusiones.txt
@@ -1,0 +1,3 @@
+10. Resultados y conclusiones
+- Resume hallazgos clave: saturación, desempeño en test, umbral recomendado.
+- Indica cómo debe operar la empresa con el modelo final.

--- a/guia_tarea/extras_opcionales.txt
+++ b/guia_tarea/extras_opcionales.txt
@@ -1,0 +1,4 @@
+Extras opcionales
+- Mostrar efectos de usar `leak_after_offer` para evidenciar data leakage.
+- Calcular métricas de negocio (ej. expected profit) usando `unit_margin_if_buy`.
+- Comparar `discount` numérico vs `discount_bucket`.

--- a/guia_tarea/requisitos_reproducibilidad.txt
+++ b/guia_tarea/requisitos_reproducibilidad.txt
@@ -1,0 +1,6 @@
+Formato y reproducibilidad
+- Declara semilla global y DATASET_ID en la primera celda.
+- Fija semillas para NumPy/sklearn y repórtalas.
+- Reporta versiones de librerías y hash SHA-256 del CSV.
+- Trabaja sólo con el dataset entregado, sin regenerar datos.
+- Entrega resultados específicos de tu dataset.


### PR DESCRIPTION
## Summary
- add a starter notebook that defines the global seed placeholder and explains how to generate helper files for the task requirements
- provide a code cell that creates per-hito text guides extracted from the assignment PDF
- check in the generated guia_tarea text files so the instructions are readily available without running the notebook

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b3baa8dc832f8edd5bb902c145b7