### PR TITLE
Organize notebook with markdown sections

### DIFF
--- a/T1 <Grupo> <10> <DATASET ID>.ipynb
+++ b/T1 <Grupo> <10> <DATASET ID>.ipynb
@@ -1,6 +1,15 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Guía estructurada de la Tarea 1\n",
+    "\n",
+    "Este notebook resume los hitos principales del enunciado para mantener un plan de trabajo ordenado. Avanza sección por sección y completa cada hito conforme desarrolles tu solución del proyecto.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -15,44 +24,140 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Guía rápida de la Tarea 1\n",
+    "## 1. E–T–P y framing\n",
     "\n",
-    "Este notebook crea archivos de texto con los puntos clave del enunciado de la tarea, para usarlos como recordatorio durante el desarrollo del proyecto. Ejecuta la celda siguiente para generar la carpeta `guia_tarea/` con un archivo por cada hito requerido.\n"
+    "- Describe la Experiencia (E), la Tarea (T) y el Performance/criterio (P).\n",
+    "- Define el framing principal como clasificación binaria de `purchase` con salida probabilística.\n",
+    "- Justifica si usarás tasas agregadas y la decisión de negocio basada en umbrales.\n",
+    "\n"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "from pathlib import Path\n",
+    "## 2. Métricas y pérdida\n",
     "\n",
-    "pasos = {\n",
-    "    \"01_ETP_y_framing.txt\": \"\"\"1. E–T–P y framing\\n- Describe la Experiencia (E), la Tarea (T) y el Performance/criterio (P).\\n- Define el framing principal como clasificación binaria de `purchase` con salida probabilística.\\n- Justifica si usarás tasas agregadas y la decisión de negocio basada en umbrales.\"\"\",\n",
-    "    \"02_metricas_y_perdida.txt\": \"\"\"2. Métricas y pérdida\\n- Usa log-loss (entropía cruzada) como pérdida principal.\\n- Reporta AUC y Brier score.\\n- Explica por qué MSE no es adecuado como objetivo principal y relaciónalo con máxima verosimilitud.\"\"\",\n",
-    "    \"03_validacion_y_capacidad.txt\": \"\"\"3. Diseño de validación y control de capacidad\\n- Define particiones train/valid/test (70/15/15) o k-fold para escoger hiperparámetros.\\n- Reentrena con los mejores hiperparámetros antes del test.\\n- Controla capacidad con regularización L2 (parámetro C) y grafica curvas train/valid vs complejidad o learning curves.\\n- Explica el trade-off sesgo–varianza.\"\"\",\n",
-    "    \"04_preprocesamiento.txt\": \"\"\"4. Preprocesamiento\\n- Explora el dataset para identificar duplicados, variables irrelevantes o leakage.\\n- Define codificación de variables categóricas, escalamiento y manejo de outliers o nulos según corresponda.\"\"\",\n",
-    "    \"05_modelado_predictivo.txt\": \"\"\"5. Modelado predictivo\\n- Entrena al menos dos modelos de clasificación (ej. regresión logística, árbol, random forest, XGBoost).\\n- Compara su desempeño inicial.\"\"\",\n",
-    "    \"06_evaluacion.txt\": \"\"\"6. Evaluación\\n- Reporta métricas de clasificación: accuracy, precision, recall, F1-score y AUC-ROC.\"\"\",\n",
-    "    \"07_discusion_resultados.txt\": \"\"\"7. Discusión de resultados\\n- Destaca variables relevantes para los modelos.\\n- Justifica columnas excluidas (especialmente leaks).\\n- Propón insights accionables para la empresa.\"\"\",\n",
-    "    \"08_politica_operativa.txt\": \"\"\"8. Política operativa y sensibilidad\\n- Formula una regla clara: contactar/ofrecer si la probabilidad estimada supera el umbral t.\\n- Analiza sensibilidad (ej. utilidad esperada por umbral) y discute implicancias.\"\"\",\n",
-    "    \"09_riesgos_y_mitigacion.txt\": \"\"\"9. Riesgos y mitigación\\n- Identifica al menos tres riesgos: leakage, sesgo de muestreo, shift temporal/segmento.\\n- Propón mitigaciones (auditoría de variables, validación por segmento o fuera de tiempo, calibration, A/B).\"\"\",\n",
-    "    \"10_resultados_y_conclusiones.txt\": \"\"\"10. Resultados y conclusiones\\n- Resume hallazgos clave: saturación, desempeño en test, umbral recomendado.\\n- Indica cómo debe operar la empresa con el modelo final.\"\"\",\n",
-    "    \"extras_opcionales.txt\": \"\"\"Extras opcionales\\n- Mostrar efectos de usar `leak_after_offer` para evidenciar data leakage.\\n- Calcular métricas de negocio (ej. expected profit) usando `unit_margin_if_buy`.\\n- Comparar `discount` numérico vs `discount_bucket`.\"\"\",\n",
-    "    \"requisitos_reproducibilidad.txt\": \"\"\"Formato y reproducibilidad\\n- Declara semilla global y DATASET_ID en la primera celda.\\n- Fija semillas para NumPy/sklearn y repórtalas.\\n- Reporta versiones de librerías y hash SHA-256 del CSV.\\n- Trabaja sólo con el dataset entregado, sin regenerar datos.\\n- Entrega resultados específicos de tu dataset.\"\"\",\n",
-    "}\n",
+    "- Usa log-loss (entropía cruzada) como pérdida principal.\n",
+    "- Reporta AUC y Brier score.\n",
+    "- Explica por qué MSE no es adecuado como objetivo principal y relaciónalo con máxima verosimilitud.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Diseño de validación y control de capacidad\n",
     "\n",
-    "destino = Path('guia_tarea')\n",
-    "destino.mkdir(exist_ok=True)\n",
-    "for nombre, contenido in pasos.items():\n",
-    "    ruta = destino / nombre\n",
-    "    ruta.write_text(contenido.strip() + '\n', encoding='utf-8')\n",
+    "- Define particiones train/valid/test (70/15/15) o k-fold para escoger hiperparámetros.\n",
+    "- Reentrena con los mejores hiperparámetros antes del test.\n",
+    "- Controla capacidad con regularización L2 (parámetro C) y grafica curvas train/valid vs. complejidad o learning curves.\n",
+    "- Explica el trade-off sesgo–varianza.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Preprocesamiento\n",
     "\n",
-    "sorted_archivos = sorted(p.name for p in destino.iterdir())\n",
-    "print(f'Se crearon/actualizaron {len(sorted_archivos)} archivos en {destino.resolve()}')\n",
-    "for archivo in sorted_archivos:\n",
-    "    print(f'- {archivo}')\n"
+    "- Explora el dataset para identificar duplicados, variables irrelevantes o leakage.\n",
+    "- Define codificación de variables categóricas, escalamiento y manejo de outliers o nulos según corresponda.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Modelado predictivo\n",
+    "\n",
+    "- Entrena al menos dos modelos de clasificación (ej. regresión logística, árbol, random forest, XGBoost).\n",
+    "- Compara su desempeño inicial.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Evaluación\n",
+    "\n",
+    "- Reporta métricas de clasificación: accuracy, precision, recall, F1-score y AUC-ROC.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Discusión de resultados\n",
+    "\n",
+    "- Destaca variables relevantes para los modelos.\n",
+    "- Justifica columnas excluidas (especialmente leaks).\n",
+    "- Propón insights accionables para la empresa.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Política operativa y sensibilidad\n",
+    "\n",
+    "- Formula una regla clara: contactar/ofrecer si la probabilidad estimada supera el umbral t.\n",
+    "- Analiza sensibilidad (ej. utilidad esperada por umbral) y discute implicancias.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Riesgos y mitigación\n",
+    "\n",
+    "- Identifica al menos tres riesgos: leakage, sesgo de muestreo, shift temporal/segmento.\n",
+    "- Propón mitigaciones (auditoría de variables, validación por segmento o fuera de tiempo, calibration, A/B).\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 10. Resultados y conclusiones\n",
+    "\n",
+    "- Resume hallazgos clave: saturación, desempeño en test, umbral recomendado.\n",
+    "- Indica cómo debe operar la empresa con el modelo final.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extras opcionales\n",
+    "\n",
+    "- Mostrar efectos de usar `leak_after_offer` para evidenciar data leakage.\n",
+    "- Calcular métricas de negocio (ej. expected profit) usando `unit_margin_if_buy`.\n",
+    "- Comparar `discount` numérico vs. `discount_bucket`.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Formato y reproducibilidad\n",
+    "\n",
+    "- Declara semilla global y DATASET_ID en la primera celda.\n",
+    "- Fija semillas para NumPy/sklearn y repórtalas.\n",
+    "- Reporta versiones de librerías y hash SHA-256 del CSV.\n",
+    "- Trabaja sólo con el dataset entregado, sin regenerar datos.\n",
+    "- Entrega resultados específicos de tu dataset.\n",
+    "\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- add an introductory markdown cell that explains how to use the task notebook
- replace the file-generation logic with ordered markdown sections for each project milestone
- keep the reproducibility configuration cell while removing the folder-creation workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b692aa5c832faf6cbce0dbfa11f6